### PR TITLE
Use exists? instead of exist

### DIFF
--- a/lib/mondrian_redis_segment_cache/cache.rb
+++ b/lib/mondrian_redis_segment_cache/cache.rb
@@ -108,7 +108,7 @@ module MondrianRedisSegmentCache
 
       mondrian_redis.with do |connection|
         connection.sscan_each(SEGMENT_HEADERS_SET_KEY) do |segment_header_base64|
-          unless connection.exists(segment_header_base64)
+          unless connection.exists?(segment_header_base64)
             connection.srem(SEGMENT_HEADERS_SET_KEY, segment_header_base64)
             next
           end


### PR DESCRIPTION
In order to suppress this warning



` `Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/srv/ballista/shared/bundle/jruby/2.3.0/gems/mondrian_redis_segment_cache-0.4.4-java/lib/mondrian_redis_segment_cache/cache.rb:111:in 'block in reload')
`

switch to using `exists?` instead of `exists`